### PR TITLE
fix: basic auth never succeeds with Werkzeug 2.3

### DIFF
--- a/ash.py
+++ b/ash.py
@@ -59,9 +59,11 @@ auth = HTTPBasicAuth()
 
 @auth.verify_password
 def verify_password(username, password):
-    db = app.config.get('T_SEARCH_BASIC_AUTH', {})
-    if username == db.get('username') and password == db.get('password'):
-        return username
+    if db := app.config.get('T_SEARCH_BASIC_AUTH', {}):
+        if username == db.get('username') and password == db.get('password'):
+            return True
+    else:
+        return True
     return False
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.3.2
+Flask-HTTPAuth-4.8.0
 elasticsearch==8.8.0
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,15 @@
-Flask==2.3.2
-Flask-HTTPAuth-4.8.0
+blinker==1.6.2
+certifi==2023.5.7
+charset-normalizer==3.2.0
+click==8.1.4
+elastic-transport==8.4.0
 elasticsearch==8.8.0
+Flask==2.3.2
+Flask-HTTPAuth==4.8.0
+idna==3.4
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.3
 requests==2.31.0
+urllib3==1.26.16
+Werkzeug==2.3.6

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -23,6 +23,17 @@ class TestSearchView:
         for kw in self.keywords:
             assert kw in resp.text
 
+    def test_search_with_basic_auth(self, client):
+        db = {
+            'username': 'foo',
+            'password': 'bar'
+        }
+        client.application.config['T_SEARCH_BASIC_AUTH'] = db
+        resp = client.get('/tweet/search.html')
+        assert resp.status_code == 401
+        resp = client.get('/tweet/search.html', auth=(db['username'], db['password']))
+        assert '<option value="wzyboy">' in resp.text
+
 
 class TestMediaReplacement:
     tweet_id = '1615425412921987074'


### PR DESCRIPTION
- fix: basic auth no longer succeeds in Werkzeug 2.3
- test: add test for search w/ basic auth
- chore: pip freeze
- fix: turn off auth if not defined
